### PR TITLE
Updated reference per latest docs

### DIFF
--- a/api-reference.txt
+++ b/api-reference.txt
@@ -24,8 +24,14 @@ POST    /api/projects/{project_id}/tasks/{task_id}/cancel/
 POST    /api/projects/{project_id}/tasks/{task_id}/remove/
 POST    /api/projects/{project_id}/tasks/{task_id}/restart/
 
-GET     /api/projects/{project_id}/tasks/{task_id}/tiles.json
-GET     /api/projects/{project_id}/tasks/{task_id}/tiles/{Z}/{X}/{Y}.png
+GET     /api/projects/{project_id}/tasks/{task_id}/orthophoto/tiles.json
+GET     /api/projects/{project_id}/tasks/{task_id}/orthophoto/tiles/{Z}/{X}/{Y}.png
+
+GET     /api/projects/{project_id}/tasks/{task_id}/dsm/tiles.json
+GET     /api/projects/{project_id}/tasks/{task_id}/dsm/tiles/{Z}/{X}/{Y}.png
+
+GET     /api/projects/{project_id}/tasks/{task_id}/dtm/tiles.json
+GET     /api/projects/{project_id}/tasks/{task_id}/dtm/tiles/{Z}/{X}/{Y}.png
 
 
 # Processing Node


### PR DESCRIPTION
In the latest WebODM version there are multiple tiles available (orthophoto, dsm, dtm). I've updated the reference doc to reflect that.

I've also made sure that the website at docs.webodm.org now has the latest documentation available. The version that was online was out of date, but I can't think of other breaking changes.